### PR TITLE
add: `ci.yaml` mainにpushされるとイメージをビルドしてDocker Hubにpushするaction

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,37 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: Create .env.local file
+        run: |
+          echo "${{ secrets.ENV_FILE }}" > .env.local
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: hikuohiku/hikuohiku:livetable


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- New Feature: GitHub Actionsを使用して、`main`ブランチへのプッシュ時にDockerイメージを自動ビルドし、Docker Hubにプッシュする設定が追加されました。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->